### PR TITLE
Fetch more discussion categories by default.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const getRepositoryData = async (authToken) => {
       query repositoryId($owner: String!, $name: String!) {
         repository(owner: $owner, name: $name) {
           id
-          discussionCategories(first: 10) {
+          discussionCategories(first: 100) {
             nodes {
               id
               name


### PR DESCRIPTION
I recently ran into an error using this Action due to the discussion category I was looking for being missing. It turns out that this is because my repository contains more than 10 discussion categories, and so the category that I need appears beyond the first page of results.

This increases the number of discussion categories this Action fetches by default to 100. Short of paginating through all available discussion categories, this helps ensure that the category we are looking for is within the set retrieved on the first page.